### PR TITLE
Reed solomon chunker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,11 @@ module github.com/TRON-US/go-btfs-chunker
 
 require (
 	github.com/ipfs/go-block-format v0.0.2
+	github.com/ipfs/go-ipfs-files v0.0.3
 	github.com/ipfs/go-ipfs-util v0.0.1
 	github.com/ipfs/go-log v0.0.1
+	github.com/klauspost/cpuid v1.2.1 // indirect
+	github.com/klauspost/reedsolomon v1.9.2
 	github.com/libp2p/go-buffer-pool v0.0.1
 	github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f
 )

--- a/go.sum
+++ b/go.sum
@@ -10,12 +10,18 @@ github.com/ipfs/go-block-format v0.0.2 h1:qPDvcP19izTjU8rgo6p7gTXZlkMkF5bz5G3fqI
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
+github.com/ipfs/go-ipfs-files v0.0.3 h1:ME+QnC3uOyla1ciRPezDW0ynQYK2ikOh9OCKAEg4uUA=
+github.com/ipfs/go-ipfs-files v0.0.3/go.mod h1:INEFm0LL2LWXBhNJ2PMIIb2w45hpXgPjNoE7yA8Y1d4=
 github.com/ipfs/go-ipfs-util v0.0.1 h1:Wz9bL2wB2YBJqggkA4dD7oSmqB4cAnpNbGrlHJulv50=
 github.com/ipfs/go-ipfs-util v0.0.1/go.mod h1:spsl5z8KUnrve+73pOhSVZND1SIxPW5RyBCNzQxlJBc=
 github.com/ipfs/go-log v0.0.1 h1:9XTUN/rW64BCG1YhPK9Hoy3q8nr4gOmHHBpgFdfw6Lc=
 github.com/ipfs/go-log v0.0.1/go.mod h1:kL1d2/hzSpI0thNYjiKfjanbVNU+IIGA/WnNESY9leM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/cpuid v1.2.1 h1:vJi+O/nMdFt0vqm8NZBI6wzALWdA2X+egi0ogNyrC/w=
+github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/reedsolomon v1.9.2 h1:E9CMS2Pqbv+C7tsrYad4YC9MfhnMVWhMRsTi7U0UB18=
+github.com/klauspost/reedsolomon v1.9.2/go.mod h1:CwCi+NUr9pqSVktrkN+Ondf06rkhYZ/pcNv7fu+8Un4=
 github.com/libp2p/go-buffer-pool v0.0.1 h1:9Rrn/H46cXjaA2HQ5Y8lyhOS1NhTkZ4yuEs2r3Eechg=
 github.com/libp2p/go-buffer-pool v0.0.1/go.mod h1:xtyIz9PMobb13WaxR6Zo1Pd1zXJKYg0a8KiIvDp3TzQ=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
@@ -52,4 +58,6 @@ golang.org/x/net v0.0.0-20190227160552-c95aed5357e7/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/sys v0.0.0-20190219092855-153ac476189d/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190302025703-b6889370fb10 h1:xQJI9OEiErEQ++DoXOHqEpzsGMrAv2Q2jyCpi7DmfpQ=
+golang.org/x/sys v0.0.0-20190302025703-b6889370fb10/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/parse_test.go
+++ b/parse_test.go
@@ -2,6 +2,7 @@ package chunk
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -32,5 +33,41 @@ func TestParseSize(t *testing.T) {
 	_, err = FromString(r, size2)
 	if err == ErrSize {
 		t.Fatal(err)
+	}
+}
+
+func TestParseReedSolomon(t *testing.T) {
+	rsCases := []struct {
+		chunker string
+		success bool
+	}{
+		{"reed-solomon", true},
+		{"reed-solomon-", false},
+		{"reed-s0lomon", false},
+		{"reed-solomon-10", false},
+		{"reed-solomon-10-20", false},
+		{"reed-solomon-10-20-0", false},
+		{"reed-solomon-10-20-100", true},
+		{"reed-solomon-0-20-100", false},
+		{"reed-solomon-10-0-100", false},
+		{"reed-solomon-150-150-100", false},
+	}
+
+	for _, rsc := range rsCases {
+		rsc := rsc // capture range variable
+		t.Run(fmt.Sprintf("test chunker %s", rsc.chunker), func(t *testing.T) {
+			// speed up with parallel test
+			t.Parallel()
+
+			max := 1000
+			r := bytes.NewReader(randBuf(t, max))
+
+			_, err := FromString(r, rsc.chunker)
+			if rsc.success && err != nil {
+				t.Fatal("failed to parse chunker", err)
+			} else if !rsc.success && err == nil {
+				t.Fatal("should fail to parse chunker but succeeded")
+			}
+		})
 	}
 }

--- a/reed_solomon.go
+++ b/reed_solomon.go
@@ -1,0 +1,150 @@
+package chunk
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"sync"
+
+	"github.com/ipfs/go-ipfs-files"
+	rs "github.com/klauspost/reedsolomon"
+)
+
+// reedSolomonSplitter implements the MultiSplitter interface and splits into multiple
+// Splitters based on data + parity shards. Each Splitter corresponds to one
+// Reed-Solomon shard and splits using the default SizeSplitter.
+// Reed-Solomon shard Splitters are safe for concurrent reading.
+// The default Splitter interface for ReedSolomonSplitter is a serialized
+// read of all shard chunks.
+type reedSolomonSplitter struct {
+	sync.Mutex
+
+	r         io.Reader
+	spls      []Splitter
+	splIndex  int
+	numData   uint64
+	numParity uint64
+	size      uint64
+	err       error
+}
+
+// NewReedSolomonSplitter takes in the number of data and parity chards, plus
+// a size splitting the shards and returns a ReedSolomonSplitter.
+func NewReedSolomonSplitter(r io.Reader, numData, numParity, size uint64) (
+	*reedSolomonSplitter, error) {
+	var fileSize int64
+	if fi, ok := r.(files.FileInfo); ok {
+		fileSize = fi.Stat().Size()
+	} else {
+		// Not a file object, but we need to know the full size before
+		// being streamed for reed-solomon encoding.
+		// Copy it to a buffer as a last resort.
+		b, err := ioutil.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		fileSize = len(b)
+		// Re-pack reader
+		r = bytes.NewReader(b)
+	}
+
+	rss, err := rs.NewStreamC(int(numData), int(numParity), true, true)
+	if err != nil {
+		return err
+	}
+
+	// Setup pipes feeding from encoded shards to individual splitter readers
+	var spls []Splitter
+	var splReaders []io.Reader    // splitting readers
+	var encReaders []io.Reader    // encoding readers
+	var dataWriters []io.Writer   // data writers, dup to both splitter and encoder
+	var parityWriters []io.Writer // parity writers, once
+	for i := 0; i < numData+numParity; i++ {
+		sr, sw := io.Pipe()
+		s := NewSizeSplitter(sr, int64(size))
+		spls = append(spls, s)
+		splReaders = append(splReaders, sr)
+		if i < numData {
+			// Create another pipe for split -> encode
+			esr, esw := io.Pipe()
+			encReaders = append(encReaders, esr)
+			// Dup to both encoder and (then) splitter
+			dataWriters = append(dataWriters, io.MultiWriter(esw, sw))
+		} else {
+			parityWriters = append(parityWriters, sw)
+		}
+	}
+
+	rsSpl := &reedSolomonSplitter{
+		r:         io.MultiReader(splReaders), // concatenate all shard chunks
+		spls:      spls,
+		numData:   numData,
+		numParity: numParity,
+		size:      size,
+	}
+
+	// Run in the background to provide streamed splitting
+	go func() {
+		// Split data into even data shards first
+		err := rss.Split(r, dataWriters, fileSize)
+		if err != nil {
+			rsSpl.setError(err)
+		}
+		// Close to finish writing
+		for _, dw := range dataWriters {
+			dw.Close()
+		}
+	}()
+
+	// Run in the background to provide streamed encoding
+	go func() {
+		// Encode parity shards
+		err := rss.Encode(encReaders, parityWriters)
+		if err != nil {
+			rsSpl.setError(err)
+		}
+		// Close to finish writing
+		for _, pw := range parityWriters {
+			pw.Close()
+		}
+	}()
+
+	return rsSpl
+}
+
+// Reader returns the overall io.Reader associated with this MultiSplitter.
+func (rss *reedSolomonSplitter) Reader() io.Reader {
+	return rss.r
+}
+
+// NextBytes produces a new chunk in the MultiSplitter.
+func (rss *reedSolomonSplitter) NextBytes() ([]byte, error) {
+	if rss.err != nil {
+		return nil, rss.err
+	}
+	// End of all splitters
+	if rss.splIndex >= len(rss.spls) {
+		return nil, io.EOF
+	}
+	b, err := rss.spls[rss.splIndex].NextBytes()
+	if err == io.EOF {
+		rss.splIndex += 1
+		// Recurse for next splitter
+		return rss.NextBytes()
+	} else if err != nil {
+		rss.setError(err)
+		return nil, err
+	}
+	return b, nil
+}
+
+// setError saves the first error so it can be returned to caller or other functions.
+func (rss *reedSolomonSplitter) setError(err error) {
+	rss.Lock()
+	defer rss.Unlock()
+
+	if rss.err != nil {
+		rss.err = err
+	}
+}

--- a/reed_solomon.go
+++ b/reed_solomon.go
@@ -156,6 +156,11 @@ func (rss *reedSolomonSplitter) NextBytes() ([]byte, error) {
 	return b, nil
 }
 
+// Splitters returns the underlying individual splitters.
+func (rss *reedSolomonSplitter) Splitters() []Splitter {
+	return rss.spls
+}
+
 // setError saves the first error so it can be returned to caller or other functions.
 func (rss *reedSolomonSplitter) setError(err error) {
 	rss.Lock()

--- a/reed_solomon.go
+++ b/reed_solomon.go
@@ -10,6 +10,12 @@ import (
 	rs "github.com/klauspost/reedsolomon"
 )
 
+const (
+	DefaultReedSolomonDataShards   = 10
+	DefaultReedSolomonParityShards = 20
+	DefaultReedSolomonShardSize    = DefaultBlockSize
+)
+
 // reedSolomonSplitter implements the MultiSplitter interface and splits into multiple
 // Splitters based on data + parity shards. Each Splitter corresponds to one
 // Reed-Solomon shard and splits using the default SizeSplitter.

--- a/reed_solomon_test.go
+++ b/reed_solomon_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	testRsDefaultNumData   = 20
-	testRsDefaultNumParity = 10
+	testRsDefaultNumData   = 10
+	testRsDefaultNumParity = 20
 	testRsDefaultSize      = 1024 * 256
 )
 

--- a/reed_solomon_test.go
+++ b/reed_solomon_test.go
@@ -1,0 +1,92 @@
+package chunk
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	rs "github.com/klauspost/reedsolomon"
+)
+
+const (
+	testRsDefaultNumData   = 20
+	testRsDefaultNumParity = 10
+	testRsDefaultSize      = 1024 * 256
+)
+
+func TestReedSolomonSplitterSplitMerge(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	max := 10000000
+	b := randBuf(t, max)
+	// Create reference split shards
+	enc, err := rs.New(testRsDefaultNumData, testRsDefaultNumParity)
+	if err != nil {
+		t.Fatal("unable to create reference reedsolomon object", err)
+	}
+	shards, err := enc.Split(b)
+	if err != nil {
+		t.Fatal("unable to split reference reedsolomon shards", err)
+	}
+	err = enc.Encode(shards)
+	if err != nil {
+		t.Fatal("unable to encode reference reedsolomon shards", err)
+	}
+	// Make sure we can reconstruct
+	var joined bytes.Buffer
+	err = enc.Join(io.Writer(&joined), shards, max)
+	if err != nil {
+		t.Fatal("unable to reference join original file", err)
+	}
+	if !bytes.Equal(joined.Bytes(), b) {
+		t.Fatal("joined file does not match original")
+	}
+	// Length for each data shard
+	shardLen := len(shards[0])
+
+	// Splitter reader
+	r := &clipReader{r: bytes.NewReader(b), size: 4000}
+	spl, err := NewReedSolomonSplitter(r,
+		testRsDefaultNumData, testRsDefaultNumParity, testRsDefaultSize)
+	if err != nil {
+		t.Fatal("unable to create reed solomon splitter", err)
+	}
+
+	c, errc := Chan(spl)
+
+	for sn := 0; sn < testRsDefaultNumData+testRsDefaultNumParity; sn++ {
+		var shard []byte
+		// Combine expected number of chunks to create shard
+		for cn := 0; cn < (shardLen+testRsDefaultSize-1)/testRsDefaultSize; cn++ {
+			select {
+			case chunk := <-c:
+				if len(chunk) > testRsDefaultSize {
+					t.Fatalf("splitter returns a larger than expected size (chunk number %d): %d",
+						cn, len(chunk))
+				}
+				shard = append(shard, chunk...)
+				// Smaller chunk must be at the end of shard
+				if len(chunk) < testRsDefaultSize {
+					break
+				}
+				// continue
+			case err := <-errc:
+				t.Fatal("failed to split all chunks", err)
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out while waiting for chunk split")
+			}
+		}
+
+		// The initial testRsDefaultNumData shards are the data shards
+		// The rest testRsDefaultNumParity shards are the parity shards,
+		// verified against a normal reed-solomon split
+		bs := shards[sn]
+		if !bytes.Equal(bs, shard) {
+			t.Fatalf("shard not correct: (shard number: %d) %d != %d, %v != %v",
+				sn, len(bs), len(shard), bs[:100], shard[:100])
+		}
+	}
+}

--- a/reed_solomon_test.go
+++ b/reed_solomon_test.go
@@ -15,15 +15,13 @@ const (
 	testRsDefaultSize      = 1024 * 256
 )
 
-func TestReedSolomonSplitterSplitMerge(t *testing.T) {
-	if testing.Short() {
-		t.SkipNow()
-	}
-
+func getReedSolomonShards(t *testing.T, dataShards, parityShards, size uint64) (
+	[][]byte, MultiSplitter) {
 	max := 10000000
 	b := randBuf(t, max)
+
 	// Create reference split shards
-	enc, err := rs.New(testRsDefaultNumData, testRsDefaultNumParity)
+	enc, err := rs.New(int(dataShards), int(parityShards))
 	if err != nil {
 		t.Fatal("unable to create reference reedsolomon object", err)
 	}
@@ -44,16 +42,27 @@ func TestReedSolomonSplitterSplitMerge(t *testing.T) {
 	if !bytes.Equal(joined.Bytes(), b) {
 		t.Fatal("joined file does not match original")
 	}
-	// Length for each data shard
-	shardLen := len(shards[0])
 
 	// Splitter reader
 	r := &clipReader{r: bytes.NewReader(b), size: 4000}
-	spl, err := NewReedSolomonSplitter(r,
-		testRsDefaultNumData, testRsDefaultNumParity, testRsDefaultSize)
+	spl, err := NewReedSolomonSplitter(r, dataShards, parityShards, size)
 	if err != nil {
 		t.Fatal("unable to create reed solomon splitter", err)
 	}
+
+	return shards, spl
+}
+
+func TestReedSolomonSplitterSplitMerge(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	shards, spl := getReedSolomonShards(t,
+		testRsDefaultNumData, testRsDefaultNumParity, testRsDefaultSize)
+
+	// Length for each data shard
+	shardLen := len(shards[0])
 
 	c, errc := Chan(spl)
 
@@ -88,5 +97,58 @@ func TestReedSolomonSplitterSplitMerge(t *testing.T) {
 			t.Fatalf("shard not correct: (shard number: %d) %d != %d, %v != %v",
 				sn, len(bs), len(shard), bs[:100], shard[:100])
 		}
+	}
+}
+
+func TestReedSolomonSplitterSplitMergeGoroutines(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	shards, spl := getReedSolomonShards(t,
+		testRsDefaultNumData, testRsDefaultNumParity, testRsDefaultSize)
+
+	// Length for each data shard
+	shardLen := len(shards[0])
+
+	spls := spl.Splitters()
+
+	// Launch goroutines to fetch each shard through the individual splitters
+	for sn := 0; sn < testRsDefaultNumData+testRsDefaultNumParity; sn++ {
+		go func(sn int) {
+			spl := spls[sn]
+			c, errc := Chan(spl)
+
+			var shard []byte
+			// Combine expected number of chunks to create shard
+			for cn := 0; cn < (shardLen+testRsDefaultSize-1)/testRsDefaultSize; cn++ {
+				select {
+				case chunk := <-c:
+					if len(chunk) > testRsDefaultSize {
+						t.Fatalf("splitter returns a larger than expected size (chunk number %d): %d",
+							cn, len(chunk))
+					}
+					shard = append(shard, chunk...)
+					// Smaller chunk must be at the end of shard
+					if len(chunk) < testRsDefaultSize {
+						break
+					}
+					// continue
+				case err := <-errc:
+					t.Fatal("failed to split all chunks", err)
+				case <-time.After(5 * time.Second):
+					t.Fatal("timed out while waiting for chunk split")
+				}
+			}
+
+			// The initial testRsDefaultNumData shards are the data shards
+			// The rest testRsDefaultNumParity shards are the parity shards,
+			// verified against a normal reed-solomon split
+			bs := shards[sn]
+			if !bytes.Equal(bs, shard) {
+				t.Fatalf("shard not correct: (shard number: %d) %d != %d, %v != %v",
+					sn, len(bs), len(shard), bs[:100], shard[:100])
+			}
+		}(sn)
 	}
 }

--- a/reed_solomon_test.go
+++ b/reed_solomon_test.go
@@ -3,6 +3,7 @@ package chunk
 import (
 	"bytes"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ const (
 
 func getReedSolomonShards(t *testing.T, dataShards, parityShards, size uint64) (
 	[][]byte, MultiSplitter) {
-	max := 10000000
+	max := 61981547
 	b := randBuf(t, max)
 
 	// Create reference split shards
@@ -114,8 +115,12 @@ func TestReedSolomonSplitterSplitMergeGoroutines(t *testing.T) {
 	spls := spl.Splitters()
 
 	// Launch goroutines to fetch each shard through the individual splitters
+	var wg sync.WaitGroup
 	for sn := 0; sn < testRsDefaultNumData+testRsDefaultNumParity; sn++ {
+		wg.Add(1)
 		go func(sn int) {
+			defer wg.Done()
+
 			spl := spls[sn]
 			c, errc := Chan(spl)
 
@@ -151,4 +156,6 @@ func TestReedSolomonSplitterSplitMergeGoroutines(t *testing.T) {
 			}
 		}(sn)
 	}
+
+	wg.Wait()
 }

--- a/splitting.go
+++ b/splitting.go
@@ -23,6 +23,16 @@ type Splitter interface {
 	NextBytes() ([]byte, error)
 }
 
+// A MultiSplitter encapsulates multiple splitters useful for concurrent
+// reading of chunks and also specialized dag building schemas.
+// Each MultiSplitter also provides Splitter-compatible interface
+// to read sequentially (the Splitter-default way).
+type MultiSplitter interface {
+	Splitter
+
+	Splitters() []Splitter
+}
+
 // SplitterGen is a splitter generator, given a reader.
 type SplitterGen func(r io.Reader) Splitter
 

--- a/splitting.go
+++ b/splitting.go
@@ -14,7 +14,7 @@ import (
 var log = logging.Logger("chunk")
 
 // DefaultBlockSize is the chunk size that splitters produce (or aim to).
-var DefaultBlockSize int64 = 1024 * 256
+const DefaultBlockSize int64 = 1024 * 256
 
 // A Splitter reads bytes from a Reader and creates "chunks" (byte slices)
 // that can be used to build DAG nodes.


### PR DESCRIPTION
Add reed solomon chunker
- Split the top level to data+parity chunks, then the rest is using normal balanced chunking
- Add new multi splitter interface and maintain compatibility with normal splitter
- Two unit tests included, one for normal splitter Chan reading, and one for concurrent multi splitter reading of all shards