### PR TITLE
Make reed solomon size check better

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/TRON-US/go-btfs-chunker
 
 require (
-	github.com/TRON-US/go-btfs-files v0.1.0
+	github.com/TRON-US/go-btfs-files v0.1.1
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-ipfs-util v0.0.1
 	github.com/ipfs/go-log v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/TRON-US/go-btfs-chunker
 
 require (
+	github.com/TRON-US/go-btfs-files v0.1.0
 	github.com/ipfs/go-block-format v0.0.2
-	github.com/ipfs/go-ipfs-files v0.0.3
 	github.com/ipfs/go-ipfs-util v0.0.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/klauspost/cpuid v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/TRON-US/go-btfs-files v0.1.0 h1:sysSuBkw4sc2yq3YN/0E5u3mwpX4ImhsqLOZ+AVECG0=
-github.com/TRON-US/go-btfs-files v0.1.0/go.mod h1:tD2vOKLcLCDNMn9rrA27n2VbNpHdKewGzEguIFY+EJ0=
+github.com/TRON-US/go-btfs-files v0.1.1 h1:GuDIiWDM66bfhfxJy8+dBL4Cfbcp3iBp7pgHpKKCw8k=
+github.com/TRON-US/go-btfs-files v0.1.1/go.mod h1:tD2vOKLcLCDNMn9rrA27n2VbNpHdKewGzEguIFY+EJ0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/TRON-US/go-btfs-files v0.1.0 h1:sysSuBkw4sc2yq3YN/0E5u3mwpX4ImhsqLOZ+AVECG0=
+github.com/TRON-US/go-btfs-files v0.1.0/go.mod h1:tD2vOKLcLCDNMn9rrA27n2VbNpHdKewGzEguIFY+EJ0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
@@ -10,8 +12,6 @@ github.com/ipfs/go-block-format v0.0.2 h1:qPDvcP19izTjU8rgo6p7gTXZlkMkF5bz5G3fqI
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
-github.com/ipfs/go-ipfs-files v0.0.3 h1:ME+QnC3uOyla1ciRPezDW0ynQYK2ikOh9OCKAEg4uUA=
-github.com/ipfs/go-ipfs-files v0.0.3/go.mod h1:INEFm0LL2LWXBhNJ2PMIIb2w45hpXgPjNoE7yA8Y1d4=
 github.com/ipfs/go-ipfs-util v0.0.1 h1:Wz9bL2wB2YBJqggkA4dD7oSmqB4cAnpNbGrlHJulv50=
 github.com/ipfs/go-ipfs-util v0.0.1/go.mod h1:spsl5z8KUnrve+73pOhSVZND1SIxPW5RyBCNzQxlJBc=
 github.com/ipfs/go-log v0.0.1 h1:9XTUN/rW64BCG1YhPK9Hoy3q8nr4gOmHHBpgFdfw6Lc=

--- a/reed_solomon.go
+++ b/reed_solomon.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"sync"
 
-	"github.com/ipfs/go-ipfs-files"
+	"github.com/TRON-US/go-btfs-files"
 	rs "github.com/klauspost/reedsolomon"
 )
 
@@ -39,9 +39,14 @@ type reedSolomonSplitter struct {
 func NewReedSolomonSplitter(r io.Reader, numData, numParity, size uint64) (
 	*reedSolomonSplitter, error) {
 	var fileSize int64
-	if fi, ok := r.(files.FileInfo); ok {
-		fileSize = fi.Stat().Size()
-	} else {
+	var err error
+	fi, ok := r.(files.FileInfo)
+	if ok {
+		fileSize, err = fi.Size()
+	}
+	// If not a FileInfo object, or fails to fetch a size, try reading
+	// the whole stream in order to obtain size (this is common for testing).
+	if !ok || err != nil {
 		// Not a file object, but we need to know the full size before
 		// being streamed for reed-solomon encoding.
 		// Copy it to a buffer as a last resort.


### PR DESCRIPTION
- Switch and use latest go-btfs-files so that `Size()` can be read correctly during online mode
- Make `Size()` failure fallback to reading stream into buffer - so it won't crash again
- Address a comment in #2 to make `NextBytes()` use more clear