### PR TITLE
Btfsbtt 663: new metadata implementation

### DIFF
--- a/rabin.go
+++ b/rabin.go
@@ -15,7 +15,7 @@ var IpfsRabinPoly = chunker.Pol(17437180132763653)
 type Rabin struct {
 	r      *chunker.Chunker
 	reader io.Reader
-	size   uint32
+	size   uint64
 }
 
 // NewRabin creates a new Rabin splitter with the given
@@ -36,7 +36,7 @@ func NewRabinMinMax(r io.Reader, min, avg, max uint64) *Rabin {
 	return &Rabin{
 		r:      ch,
 		reader: r,
-		size:   uint32(avg),
+		size:   uint64(avg),
 	}
 }
 
@@ -56,6 +56,6 @@ func (r *Rabin) Reader() io.Reader {
 }
 
 // Size returns the chunk size of this Splitter.
-func (r *Rabin) Chunksize() uint32 {
+func (r *Rabin) Chunksize() uint64 {
 	return r.size
 }

--- a/rabin.go
+++ b/rabin.go
@@ -15,6 +15,7 @@ var IpfsRabinPoly = chunker.Pol(17437180132763653)
 type Rabin struct {
 	r      *chunker.Chunker
 	reader io.Reader
+	size   uint32
 }
 
 // NewRabin creates a new Rabin splitter with the given
@@ -35,6 +36,7 @@ func NewRabinMinMax(r io.Reader, min, avg, max uint64) *Rabin {
 	return &Rabin{
 		r:      ch,
 		reader: r,
+		size:   uint32(avg),
 	}
 }
 
@@ -51,4 +53,9 @@ func (r *Rabin) NextBytes() ([]byte, error) {
 // Reader returns the io.Reader associated to this Splitter.
 func (r *Rabin) Reader() io.Reader {
 	return r.reader
+}
+
+// Size returns the chunk size of this Splitter.
+func (r *Rabin) Chunksize() uint32 {
+	return r.size
 }

--- a/rabin.go
+++ b/rabin.go
@@ -56,6 +56,6 @@ func (r *Rabin) Reader() io.Reader {
 }
 
 // Size returns the chunk size of this Splitter.
-func (r *Rabin) Chunksize() uint64 {
+func (r *Rabin) ChunkSize() uint64 {
 	return r.size
 }

--- a/reed_solomon.go
+++ b/reed_solomon.go
@@ -144,8 +144,8 @@ func (rss *reedSolomonSplitter) NextBytes() ([]byte, error) {
 	return b, nil
 }
 
-// Chunksize returns the chunk size of this Splitter.
-func (rss *reedSolomonSplitter) Chunksize() uint64 {
+// ChunkSize returns the chunk size of this Splitter.
+func (rss *reedSolomonSplitter) ChunkSize() uint64 {
 	return uint64(rss.size)
 }
 

--- a/reed_solomon.go
+++ b/reed_solomon.go
@@ -144,6 +144,11 @@ func (rss *reedSolomonSplitter) NextBytes() ([]byte, error) {
 	return b, nil
 }
 
+// Chunksize returns the chunk size of this Splitter.
+func (rss *reedSolomonSplitter) Chunksize() uint32 {
+	return uint32(rss.size)
+}
+
 // Splitters returns the underlying individual splitters.
 func (rss *reedSolomonSplitter) Splitters() []Splitter {
 	return rss.spls

--- a/reed_solomon.go
+++ b/reed_solomon.go
@@ -145,8 +145,8 @@ func (rss *reedSolomonSplitter) NextBytes() ([]byte, error) {
 }
 
 // Chunksize returns the chunk size of this Splitter.
-func (rss *reedSolomonSplitter) Chunksize() uint32 {
-	return uint32(rss.size)
+func (rss *reedSolomonSplitter) Chunksize() uint64 {
+	return uint64(rss.size)
 }
 
 // Splitters returns the underlying individual splitters.

--- a/splitting.go
+++ b/splitting.go
@@ -21,6 +21,7 @@ const DefaultBlockSize int64 = 1024 * 256
 type Splitter interface {
 	Reader() io.Reader
 	NextBytes() ([]byte, error)
+	Chunksize() uint32
 }
 
 // A MultiSplitter encapsulates multiple splitters useful for concurrent
@@ -112,4 +113,9 @@ func (ss *sizeSplitterv2) NextBytes() ([]byte, error) {
 // Reader returns the io.Reader associated to this Splitter.
 func (ss *sizeSplitterv2) Reader() io.Reader {
 	return ss.r
+}
+
+// Size returns the chunk size of this Splitter.
+func (ss *sizeSplitterv2) Chunksize() uint32 {
+	return ss.size
 }

--- a/splitting.go
+++ b/splitting.go
@@ -21,7 +21,7 @@ const DefaultBlockSize int64 = 1024 * 256
 type Splitter interface {
 	Reader() io.Reader
 	NextBytes() ([]byte, error)
-	Chunksize() uint32
+	Chunksize() uint64
 }
 
 // A MultiSplitter encapsulates multiple splitters useful for concurrent
@@ -116,6 +116,6 @@ func (ss *sizeSplitterv2) Reader() io.Reader {
 }
 
 // Size returns the chunk size of this Splitter.
-func (ss *sizeSplitterv2) Chunksize() uint32 {
-	return ss.size
+func (ss *sizeSplitterv2) Chunksize() uint64 {
+	return uint64(ss.size)
 }

--- a/splitting.go
+++ b/splitting.go
@@ -21,7 +21,7 @@ const DefaultBlockSize int64 = 1024 * 256
 type Splitter interface {
 	Reader() io.Reader
 	NextBytes() ([]byte, error)
-	Chunksize() uint64
+	ChunkSize() uint64
 }
 
 // A MultiSplitter encapsulates multiple splitters useful for concurrent
@@ -116,6 +116,6 @@ func (ss *sizeSplitterv2) Reader() io.Reader {
 }
 
 // Size returns the chunk size of this Splitter.
-func (ss *sizeSplitterv2) Chunksize() uint64 {
+func (ss *sizeSplitterv2) ChunkSize() uint64 {
 	return uint64(ss.size)
 }


### PR DESCRIPTION
Added additional method Chunksize() to Splitter interface for the new metadata implementation.