### PR TITLE
Add MetaData() interface to splitters

### DIFF
--- a/rabin.go
+++ b/rabin.go
@@ -55,7 +55,12 @@ func (r *Rabin) Reader() io.Reader {
 	return r.reader
 }
 
-// Size returns the chunk size of this Splitter.
+// ChunkSize returns the chunk size of this Splitter.
 func (r *Rabin) ChunkSize() uint64 {
 	return r.size
+}
+
+// MetaData returns metadata object from this chunker (none).
+func (r *Rabin) MetaData() interface{} {
+	return nil
 }

--- a/reed_solomon.go
+++ b/reed_solomon.go
@@ -28,6 +28,7 @@ type reedSolomonSplitter struct {
 	numData   uint64
 	numParity uint64
 	size      uint64
+	fileSize  uint64
 	err       error
 }
 
@@ -109,6 +110,7 @@ func NewReedSolomonSplitter(r io.Reader, numData, numParity, size uint64) (
 		numData:   numData,
 		numParity: numParity,
 		size:      size,
+		fileSize:  uint64(fileSize),
 	}
 
 	return rsSpl, nil
@@ -152,6 +154,17 @@ func (rss *reedSolomonSplitter) ChunkSize() uint64 {
 // Splitters returns the underlying individual splitters.
 func (rss *reedSolomonSplitter) Splitters() []Splitter {
 	return rss.spls
+}
+
+type RsMetaMap struct {
+	NumData   uint64
+	NumParity uint64
+	FileSize  uint64
+}
+
+// MetaData returns metadata object of this reed solomon scheme.
+func (rss *reedSolomonSplitter) MetaData() interface{} {
+	return &RsMetaMap{NumData: rss.numData, NumParity: rss.numParity, FileSize: rss.fileSize}
 }
 
 // setError saves the first error so it can be returned to caller or other functions.

--- a/reed_solomon_test.go
+++ b/reed_solomon_test.go
@@ -51,6 +51,17 @@ func getReedSolomonShards(t *testing.T, dataShards, parityShards, size uint64) (
 		t.Fatal("unable to create reed solomon splitter", err)
 	}
 
+	md, ok := spl.MetaData().(*RsMetaMap)
+	if !ok {
+		t.Fatal("unable to get metadata map type from reed solomon splitter")
+	}
+	if md.NumData != dataShards ||
+		md.NumParity != parityShards ||
+		md.FileSize != uint64(max) {
+		t.Fatalf("reed solomon splitter metadata [%d %d %d] do not match set parameters [%d %d %d]",
+			md.NumData, md.NumParity, md.FileSize, dataShards, parityShards, max)
+	}
+
 	return shards, spl
 }
 

--- a/splitting.go
+++ b/splitting.go
@@ -22,6 +22,7 @@ type Splitter interface {
 	Reader() io.Reader
 	NextBytes() ([]byte, error)
 	ChunkSize() uint64
+	MetaData() interface{}
 }
 
 // A MultiSplitter encapsulates multiple splitters useful for concurrent
@@ -121,9 +122,21 @@ func (ss *sizeSplitterv2) Reader() io.Reader {
 	return ss.r
 }
 
-// Size returns the chunk size of this Splitter.
+// ChunkSize returns the chunk size of this Splitter.
 func (ss *sizeSplitterv2) ChunkSize() uint64 {
 	return uint64(ss.size)
+}
+
+// MetaData returns metadata object from this chunker (none).
+func (ss *sizeSplitterv2) MetaData() interface{} {
+	return nil
+}
+
+func NewMetaSplitter(r io.Reader, size uint64) Splitter {
+	return &MetaSplitter{
+		r:    r,
+		size: size,
+	}
 }
 
 // NextBytes produces a new chunk.
@@ -160,9 +173,7 @@ func (ms *MetaSplitter) ChunkSize() uint64 {
 	return uint64(ms.size)
 }
 
-func NewMetaSplitter(r io.Reader, size uint64) Splitter {
-	return &MetaSplitter{
-		r:    r,
-		size: size,
-	}
+// MetaData returns metadata object from this chunker (none).
+func (ms *MetaSplitter) MetaData() interface{} {
+	return nil
 }


### PR DESCRIPTION
Add a MetaData() interface to chunkers, specifically for Reed Solomon to
return relevant chunk-related information of the scheme.

Note that MetaData() returns an interface{} instead of
1) []byte: we should leave encoding/decoding schemas to callers (json,
proto, etc.)
2) map[string]interface{}: map makes it easier to debug and log, but not
for field type inteference when caller decodes the value